### PR TITLE
Fixed nova resource discovery

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Laravel\Nova\Nova;
 
 /*
 |--------------------------------------------------------------------------
@@ -26,12 +27,7 @@ Route::get('tokens/{resourceName}/{id}', function (
     $id,
     Request $request
 ) {
-    $resource = \Laravel\Nova\Fields\ResourceRelationshipGuesser::guessResource(
-        $resourceName
-    );
-
-    return $resource
-        ::newModel()
+    return Nova::modelInstanceForKey($resourceName)
         ->with('tokens')
         ->where('id', $id)
         ->first();
@@ -42,11 +38,7 @@ Route::post('tokens/{resourceName}/{id}', function (
     $id,
     Request $request
 ) {
-    $resource = \Laravel\Nova\Fields\ResourceRelationshipGuesser::guessResource(
-        $resourceName
-    );
-
-    $user = $resource::newModel()->find($id);
+    $user = Nova::modelInstanceForKey($resourceName)->find($id);
 
     $abilities =
         $request->abilities == ""
@@ -67,12 +59,7 @@ Route::post('tokens/{resourceName}/{id}/revoke', function (
     $id,
     Request $request
 ) {
-    $resource = \Laravel\Nova\Fields\ResourceRelationshipGuesser::guessResource(
-        $resourceName
-    );
-
-    $user = $resource
-        ::newModel()
+    $user = Nova::modelInstanceForKey($resourceName)
         ->with('tokens')
         ->where('id', $id)
         ->first();


### PR DESCRIPTION
Hello. Nice package.
`ResourceRelationshipGuesser` is inappropriate for this action. It simply searches for class at `App\Nova\RESOURCE_CLASS` which is not always where you put the Nova resource for User. After this fails it returns a class blindly like `Illuminate\Routing\User`. Laravel Nova "knows" where every resource is placed to function properly so you should call the core functions on `Laravel\Nova\Nova` like `modelInstanceForKey`, `resourceForKey` and similar. Using this method I believe your package can work for any model that `HasApiTokens` provided that that model has a corresponding Nova resource (which I think will always be true otherwise this endpoint would not be called).

I am using the package with these updates in my dev server, everything seems fine.
Please validate and merge this as soon as possible. My app is going to production in one month and this package has nice UI and saves me a lot of time.
Thank you for your work!