### PR TITLE
Sanctum-Tokens fails if primary keys are not named `id`

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -29,8 +29,7 @@ Route::get("tokens/{resourceName}/{id}", function (
 ) {
     return Nova::modelInstanceForKey($resourceName)
         ->with("tokens")
-        ->where("id", $id)
-        ->first();
+        ->find($id);
 });
 
 Route::post("tokens/{resourceName}/{id}", function (
@@ -58,11 +57,10 @@ Route::post("tokens/{resourceName}/{id}/revoke", function (
 ) {
     $user = Nova::modelInstanceForKey($resourceName)
         ->with("tokens")
-        ->where("id", $id)
-        ->first();
+        ->find($id);
 
     return $user
         ->tokens()
-        ->where("id", $request->token_id)
+        ->whereKey($request->token_id)
         ->delete();
 });


### PR DESCRIPTION
The implementation has a hardcoded expectation on the naming of model primary keys which are changeable in eloquent. The proposed change makes the implementation adaptable to the changes done by developers by using eloquent's standard functions to operate on models.