### PR TITLE
refactor(routes): Reorganize routes with a controller

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use Laravel\Nova\Nova;
 
 /*
 |--------------------------------------------------------------------------
@@ -15,52 +13,7 @@ use Laravel\Nova\Nova;
 |
 */
 
-// Route::get('/endpoint', function (Request $request) {
-//     //
-// });
-
-/**
- * Get tokes for provided user id
- */
-Route::get("tokens/{resourceName}/{id}", function (
-    $resourceName,
-    $id,
-    Request $request
-) {
-    return Nova::modelInstanceForKey($resourceName)
-        ->with("tokens")
-        ->find($id);
-});
-
-Route::post("tokens/{resourceName}/{id}", function (
-    $resourceName,
-    $id,
-    Request $request
-) {
-    $user = Nova::modelInstanceForKey($resourceName)->find($id);
-
-    $abilities = collect(explode(",", $request->abilities))
-        ->map(function ($item) {
-            return trim($item);
-        })
-        ->toArray();
-
-    $token = $user->createToken($request->name, $abilities);
-
-    return $token->plainTextToken;
-});
-
-Route::post("tokens/{resourceName}/{id}/revoke", function (
-    $resourceName,
-    $id,
-    Request $request
-) {
-    $user = Nova::modelInstanceForKey($resourceName)
-        ->with("tokens")
-        ->find($id);
-
-    return $user
-        ->tokens()
-        ->whereKey($request->token_id)
-        ->delete();
-});
+// Get tokes for provided user id
+Route::get('tokens/{resourceName}/{id}', '\Jeffbeltran\SanctumTokens\Http\SanctumController@tokens');
+Route::post('tokens/{resourceName}/{id}', '\Jeffbeltran\SanctumTokens\Http\SanctumController@createToken');
+Route::post('tokens/{resourceName}/{id}/revoke', '\Jeffbeltran\SanctumTokens\Http\SanctumController@revoke');

--- a/src/Http/SanctumController.php
+++ b/src/Http/SanctumController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jeffbeltran\SanctumTokens\Http;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Nova;
+
+class SanctumController
+{
+    public function tokens($resourceName, $id)
+    {
+        return Nova::modelInstanceForKey($resourceName)
+            ->with('tokens')
+            ->find($id);
+    }
+
+    public function createToken(Request $request, $resourceName, $id)
+    {
+        $user = Nova::modelInstanceForKey($resourceName)->find($id);
+
+        $abilities = collect(explode(',', $request->abilities))
+            ->map(function ($item) {
+                return trim($item);
+            })
+            ->toArray();
+
+        $token = $user->createToken($request->name, $abilities);
+
+        return $token->plainTextToken;
+    }
+
+    public function revoke(Request $request, $resourceName, $id)
+    {
+        $user = Nova::modelInstanceForKey($resourceName)
+            ->with('tokens')
+            ->find($id);
+
+        return $user
+            ->tokens()
+            ->whereKey($request->token_id)
+            ->delete();
+    }
+}

--- a/src/SanctumTokens.php
+++ b/src/SanctumTokens.php
@@ -7,15 +7,15 @@ use Laravel\Nova\ResourceTool;
 class SanctumTokens extends ResourceTool
 {
     private $defaultOptions = [
-        "showAbilities" => true,
-        "defaultAbilities" => "*",
+        'showAbilities' => true,
+        'defaultAbilities' => '*',
     ];
 
     public function __construct()
     {
         parent::__construct();
 
-        $this->meta["options"] = $this->defaultOptions;
+        $this->meta['options'] = $this->defaultOptions;
     }
 
     /**
@@ -25,36 +25,30 @@ class SanctumTokens extends ResourceTool
      */
     public function name()
     {
-        return "Sanctum Tokens";
-    }
-
-    private function updateOption(array $value)
-    {
-        $this->meta["options"] = array_merge($this->meta["options"], $value);
-        return $this;
+        return 'Sanctum Tokens';
     }
 
     /**
-     * This will hide the references to abilities from the UI
+     * This will hide the references to abilities from the UI.
      *
      * @return $this
      */
     public function hideAbilities()
     {
         return $this->updateOption([
-            "showAbilities" => false,
+            'showAbilities' => false,
         ]);
     }
 
     /**
-     * This will hide the references to abilities from the UI
+     * This will hide the references to abilities from the UI.
      *
      * @return $this
      */
     public function defaultAbilities(array $abilities)
     {
         return $this->updateOption([
-            "defaultAbilities" => implode(", ", $abilities),
+            'defaultAbilities' => implode(', ', $abilities),
         ]);
     }
 
@@ -65,6 +59,13 @@ class SanctumTokens extends ResourceTool
      */
     public function component()
     {
-        return "sanctum-tokens";
+        return 'sanctum-tokens';
+    }
+
+    private function updateOption(array $value)
+    {
+        $this->meta['options'] = array_merge($this->meta['options'], $value);
+
+        return $this;
     }
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -70,7 +70,7 @@ class ToolServiceProvider extends ServiceProvider
      */
     protected function routes()
     {
-        if ($this->app->routesAreCached()) {
+        if ($this->app->routesAreCached() || config('sanctum.routes') === false) {
             return;
         }
 

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -14,7 +14,7 @@ class ToolServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public static $name = "sanctum-tokens";
+    public static $name = 'sanctum-tokens';
 
     /**
      * Bootstrap any application services.
@@ -28,55 +28,16 @@ class ToolServiceProvider extends ServiceProvider
         });
 
         $this->publishes([
-            __DIR__ . "/../resources/lang" => resource_path(
-                "lang/vendor/" . static::$name
+            __DIR__.'/../resources/lang' => resource_path(
+                'lang/vendor/'.static::$name
             ),
         ]);
 
         Nova::serving(function (ServingNova $event) {
-            Nova::script("sanctum-tokens", __DIR__ . "/../dist/js/tool.js");
-            Nova::style("sanctum-tokens", __DIR__ . "/../dist/css/tool.css");
+            Nova::script('sanctum-tokens', __DIR__.'/../dist/js/tool.js');
+            Nova::style('sanctum-tokens', __DIR__.'/../dist/css/tool.css');
             Nova::translations(static::getTranslations());
         });
-    }
-
-    /**
-     * Get the translation keys from file.
-     *
-     * @return array
-     */
-    private static function getTranslations(): array
-    {
-        $translationFile = resource_path(
-            "lang/vendor/" . static::$name . "/" . app()->getLocale() . ".json"
-        );
-
-        if (!is_readable($translationFile)) {
-            $translationFile =
-                __DIR__ . "/../resources/lang/" . app()->getLocale() . ".json";
-
-            if (!is_readable($translationFile)) {
-                return [];
-            }
-        }
-
-        return json_decode(file_get_contents($translationFile), true);
-    }
-
-    /**
-     * Register the tool's routes.
-     *
-     * @return void
-     */
-    protected function routes()
-    {
-        if ($this->app->routesAreCached() || config('sanctum.routes') === false) {
-            return;
-        }
-
-        Route::middleware(["nova"])
-            ->prefix("nova-vendor/" . static::$name)
-            ->group(__DIR__ . "/../routes/api.php");
     }
 
     /**
@@ -86,6 +47,42 @@ class ToolServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+    }
+
+    /**
+     * Register the tool's routes.
+     *
+     * @return void
+     */
+    protected function routes()
+    {
+        if ($this->app->routesAreCached() || false === config('sanctum.routes')) {
+            return;
+        }
+
+        Route::middleware(['nova'])
+            ->prefix('nova-vendor/'.static::$name)
+            ->group(__DIR__.'/../routes/api.php');
+    }
+
+    /**
+     * Get the translation keys from file.
+     */
+    private static function getTranslations(): array
+    {
+        $translationFile = resource_path(
+            'lang/vendor/'.static::$name.'/'.app()->getLocale().'.json'
+        );
+
+        if (!is_readable($translationFile)) {
+            $translationFile =
+                __DIR__.'/../resources/lang/'.app()->getLocale().'.json';
+
+            if (!is_readable($translationFile)) {
+                return [];
+            }
+        }
+
+        return json_decode(file_get_contents($translationFile), true);
     }
 }


### PR DESCRIPTION
Hi,

I've refactored the routes with a controller. Now, it is possible to execute:

```sh
$ php artisan route:cache
Route cache cleared!
Routes cached successfully!

$ php artisan optimize
Configuration cache cleared!
Configuration cached successfully!
Route cache cleared!
Routes cached successfully!
Files cached successfully!
```

This improvement solved the issue #32 

PS: I've also applied PSR2 styling to the files.

